### PR TITLE
Fix sidebar with no background when viewing articles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -120,7 +120,7 @@ canonifyurls = true
   syntaxHighlighter = "highlight.js"
 
   # Hide sidebar on all article page to let article take full width to improve reading, and enjoy wide images and cover images. (true: enable, false: disable)
-  clearReading = true
+  clearReading = false
 
   # Define categories will create hierarchy between parents: `categories = ["foo", "bar"]` will consider "bar" a sub-category of "foo". 
   # If false it will flat categories.
@@ -149,8 +149,8 @@ canonifyurls = true
   # Current image is on AWS S3 and delivered by AWS CloudFront.
   # Otherwise put your image in folder `static/_images/` (development)  or in `source/assets/images/` if you can't or don't want to build the theme,
   # and use relative url : `your-image.png`
-  coverImage = "cover.jpg"
-  #coverImage = "navy_blue.jpg"
+  #coverImage = "cover.jpg"
+  coverImage = "navy_blue.jpg"
 
   # Display an image gallery at the end of a post which have photos variables (false: disabled, true: enabled)
   imageGallery = true


### PR DESCRIPTION
On the production Netlify website, on an Article page, when you expand the collapsed sidebar, it has no background color. The following changes were made to fix this:

update config.toml:
- turn off clearReading
- revert coverImage to navy blue

This worked on the staging branch deploy site.